### PR TITLE
feat: reduce server polling load with manual refresh

### DIFF
--- a/app/games/[gameId]/__tests__/game-page.test.tsx
+++ b/app/games/[gameId]/__tests__/game-page.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { GamePage } from "../game-page";
+
+vi.mock("next/navigation", () => ({
+  useParams: vi.fn().mockReturnValue({ gameId: "game-abc" }),
+}));
+
+vi.mock("@/components/auth/require-auth", () => ({
+  RequireAuth: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/hooks/use-game-state", () => ({
+  useGameState: vi.fn(),
+}));
+
+vi.mock("@/components/game/game-board", () => ({
+  GameBoard: ({
+    onRefresh,
+    isRefreshing,
+  }: {
+    onRefresh?: () => Promise<void>;
+    isRefreshing?: boolean;
+  }) => (
+    <div>
+      <span data-testid="refreshing">{String(isRefreshing)}</span>
+      <button onClick={onRefresh}>Refresh</button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/game/score-board", () => ({
+  ScoreBoard: () => <div />,
+}));
+
+import { useGameState } from "@/lib/hooks/use-game-state";
+
+const mockUseGameState = vi.mocked(useGameState);
+
+const baseState = {
+  game: null,
+  started: {
+    status: "BIDDING" as const,
+    id: "game-abc",
+    active_player_id: "other",
+    players: [],
+    scores: {},
+    bid_amount: null,
+    bidder_player_id: null,
+    dealer_player_id: null,
+    trump: null,
+  },
+  completed: null,
+  loading: false,
+  error: null,
+  isStale: false,
+  myTurn: false,
+  hand: [],
+  playerId: "player-1",
+  phase: "BIDDING" as const,
+  refetch: vi.fn().mockResolvedValue(undefined),
+};
+
+describe("GamePage handleRefresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseGameState.mockReturnValue({
+      ...baseState,
+      refetch: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  it("resets isRefreshing to false after refetch resolves", async () => {
+    render(<GamePage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("refreshing").textContent).toBe("false");
+    });
+  });
+
+  it("resets isRefreshing to false after refetch rejects", async () => {
+    mockUseGameState.mockReturnValue({
+      ...baseState,
+      refetch: vi.fn().mockRejectedValue(new Error("network error")),
+    });
+
+    render(<GamePage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("refreshing").textContent).toBe("false");
+    });
+  });
+});

--- a/app/games/[gameId]/game-page.tsx
+++ b/app/games/[gameId]/game-page.tsx
@@ -6,6 +6,7 @@ import { ScoreBoard } from "@/components/game/score-board";
 import { useGameState } from "@/lib/hooks/use-game-state";
 import { useParams } from "next/navigation";
 import Link from "next/link";
+import { useState } from "react";
 
 function GameContent() {
   const { gameId } = useParams<{ gameId: string }>();
@@ -20,7 +21,18 @@ function GameContent() {
     playerId,
     phase,
     refetch,
-  } = useGameState({ gameId });
+  } = useGameState({ gameId, interval: 30000 });
+
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  async function handleRefresh() {
+    setIsRefreshing(true);
+    try {
+      await refetch();
+    } finally {
+      setIsRefreshing(false);
+    }
+  }
 
   if (loading) {
     return (
@@ -68,6 +80,8 @@ function GameContent() {
           isStale={isStale}
           playerId={playerId}
           onActionComplete={refetch}
+          onRefresh={handleRefresh}
+          isRefreshing={isRefreshing}
         />
         <aside className="hidden lg:flex lg:flex-col lg:gap-4">
           <ScoreBoard scores={scores} currentPlayerId={playerId} />

--- a/app/games/[gameId]/game-page.tsx
+++ b/app/games/[gameId]/game-page.tsx
@@ -6,7 +6,7 @@ import { ScoreBoard } from "@/components/game/score-board";
 import { useGameState } from "@/lib/hooks/use-game-state";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 function GameContent() {
   const { gameId } = useParams<{ gameId: string }>();
@@ -25,14 +25,16 @@ function GameContent() {
 
   const [isRefreshing, setIsRefreshing] = useState(false);
 
-  async function handleRefresh() {
+  const handleRefresh = useCallback(async () => {
     setIsRefreshing(true);
     try {
       await refetch();
+    } catch {
+      // error display deferred; isRefreshing resets via finally
     } finally {
       setIsRefreshing(false);
     }
-  }
+  }, [refetch]);
 
   if (loading) {
     return (

--- a/components/game/__tests__/game-status-bar.test.tsx
+++ b/components/game/__tests__/game-status-bar.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { GameStatusBar } from "../game-status-bar";
+
+const noop = vi.fn().mockResolvedValue(undefined);
+
+const defaultProps = {
+  phase: "BIDDING" as const,
+  myTurn: false,
+  isStale: false,
+  onRefresh: noop,
+  isRefreshing: false,
+};
+
+describe("GameStatusBar", () => {
+  it("shows 'Your turn' pill when myTurn is true", () => {
+    render(<GameStatusBar {...defaultProps} myTurn={true} />);
+    expect(screen.getByText("Your turn")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("shows Refresh button when myTurn is false and game is active", () => {
+    render(
+      <GameStatusBar
+        {...defaultProps}
+        myTurn={false}
+        activePlayerId="abc12345"
+      />,
+    );
+    const button = screen.getByRole("button");
+    expect(button).toBeInTheDocument();
+    expect(screen.queryByText("Your turn")).toBeNull();
+  });
+
+  it("shows neither turn indicator when phase is WON", () => {
+    render(<GameStatusBar {...defaultProps} phase="WON" myTurn={false} />);
+    expect(screen.queryByText("Your turn")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("calls onRefresh when Refresh button is clicked", async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    render(
+      <GameStatusBar {...defaultProps} myTurn={false} onRefresh={onRefresh} />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("button is disabled when isRefreshing is true", () => {
+    render(
+      <GameStatusBar {...defaultProps} myTurn={false} isRefreshing={true} />,
+    );
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("disabled button does not call onRefresh when clicked", async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    render(
+      <GameStatusBar
+        {...defaultProps}
+        myTurn={false}
+        isRefreshing={true}
+        onRefresh={onRefresh}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it("Refresh button meets 44px touch target", () => {
+    render(<GameStatusBar {...defaultProps} myTurn={false} />);
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("min-h-[44px]");
+  });
+});

--- a/components/game/game-board.tsx
+++ b/components/game/game-board.tsx
@@ -27,8 +27,8 @@ interface GameBoardProps {
   isStale: boolean;
   playerId: string;
   onActionComplete: () => Promise<void>;
-  onRefresh: () => Promise<void>;
-  isRefreshing: boolean;
+  onRefresh?: () => Promise<void>;
+  isRefreshing?: boolean;
 }
 
 export function GameBoard({

--- a/components/game/game-board.tsx
+++ b/components/game/game-board.tsx
@@ -27,6 +27,8 @@ interface GameBoardProps {
   isStale: boolean;
   playerId: string;
   onActionComplete: () => Promise<void>;
+  onRefresh: () => Promise<void>;
+  isRefreshing: boolean;
 }
 
 export function GameBoard({
@@ -37,6 +39,8 @@ export function GameBoard({
   isStale,
   playerId,
   onActionComplete,
+  onRefresh,
+  isRefreshing,
 }: GameBoardProps) {
   const [actionInFlight, setActionInFlight] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -58,7 +62,13 @@ export function GameBoard({
   if (completed) {
     return (
       <div className="flex flex-col gap-4">
-        <GameStatusBar phase="WON" myTurn={false} isStale={isStale} />
+        <GameStatusBar
+          phase="WON"
+          myTurn={false}
+          isStale={isStale}
+          onRefresh={onRefresh}
+          isRefreshing={isRefreshing}
+        />
         <div className="rounded-lg bg-green-50 p-6 text-center dark:bg-green-900">
           <h2 className="text-xl font-bold dark:text-gray-100">Game Over</h2>
           <p className="mt-2 text-lg dark:text-gray-200">
@@ -91,6 +101,8 @@ export function GameBoard({
         dealerPlayerId={started.dealer_player_id}
         playerId={playerId}
         trump={started.trump}
+        onRefresh={onRefresh}
+        isRefreshing={isRefreshing}
       />
 
       <div className="lg:hidden">

--- a/components/game/game-status-bar.tsx
+++ b/components/game/game-status-bar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { GameStatus, SelectableSuit } from "@/lib/api/types";
 import { SUIT_SYMBOL } from "./card-labels";
 
@@ -5,6 +7,8 @@ interface GameStatusBarProps {
   phase: GameStatus;
   myTurn: boolean;
   isStale: boolean;
+  onRefresh?: () => Promise<void>;
+  isRefreshing?: boolean;
   activePlayerId?: string | null;
   bidAmount?: number | null;
   bidderPlayerId?: string | null;
@@ -36,6 +40,8 @@ export function GameStatusBar({
   phase,
   myTurn,
   isStale,
+  onRefresh = async () => {},
+  isRefreshing = false,
   activePlayerId,
   bidAmount,
   bidderPlayerId,
@@ -57,19 +63,26 @@ export function GameStatusBar({
         </div>
 
         <div className="flex items-center gap-3">
-          {phase !== "WON" && (
-            <span
-              className={`rounded-full px-3 py-1 text-sm font-medium ${
-                myTurn
-                  ? "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300"
-                  : "bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
-              }`}
-            >
-              {myTurn
-                ? "Your turn"
-                : `Waiting for ${activePlayerId?.slice(0, 8) ?? "..."}`}
-            </span>
-          )}
+          {phase !== "WON" &&
+            (myTurn ? (
+              <span className="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-700 dark:bg-blue-900 dark:text-blue-300">
+                Your turn
+              </span>
+            ) : (
+              <button
+                onClick={onRefresh}
+                disabled={isRefreshing}
+                className={`min-h-[44px] rounded-full px-3 text-sm font-medium ${
+                  isRefreshing
+                    ? "cursor-not-allowed bg-gray-200 text-gray-400 dark:bg-gray-700 dark:text-gray-500"
+                    : "cursor-pointer bg-gray-200 text-gray-600 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                }`}
+              >
+                {isRefreshing
+                  ? `Waiting for ${activePlayerId?.slice(0, 8) ?? "..."}...`
+                  : `Waiting for ${activePlayerId?.slice(0, 8) ?? "..."} ↻`}
+              </button>
+            ))}
 
           {isStale && (
             <span className="rounded-full bg-yellow-100 px-2 py-1 text-xs text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300">

--- a/docs/brainstorms/polling-manual-refresh-requirements.md
+++ b/docs/brainstorms/polling-manual-refresh-requirements.md
@@ -1,0 +1,65 @@
+---
+title: Manual Refresh Button (Polling Reduction MVP)
+date: 2026-04-21
+status: draft
+---
+
+# Manual Refresh Button — Polling Reduction MVP
+
+## Problem
+
+The current polling hook (`lib/hooks/use-polling.ts`) fetches game state every 3 seconds for all connected clients. Until SSE is available, this creates unnecessary server load — especially for players who are waiting on opponents and not taking any action.
+
+## Goal
+
+Reduce server polling load for the MVP by tying the refresh cadence to turn state, giving idle players a manual refresh button instead of continuous 3-second polling.
+
+## Key Insight
+
+Polling is only wasteful when it is **not** the current player's turn. When it is their turn, game state is already fresh (fetched after the last action via `onActionComplete`). The heaviest load comes from all opponents polling every 3 seconds while waiting.
+
+## Scope
+
+### In scope
+- Disable the active poll timer for the entire duration that it **is** the current player's turn (level-based, not edge-triggered — polling stays off until the player acts and the turn changes)
+- Reduce the background poll interval to 30 seconds when it is **not** the current player's turn (safety net / tab-restore fallback)
+- Add a manual "Refresh" button visible in the same location as the "Your turn" indicator, shown only when it is **not** the player's turn
+- The button triggers `refetch` from `useGameState`
+- Tab-focus and online-event triggered refreshes (already in the hook) are retained as-is
+
+### Out of scope
+- SSE or WebSocket implementation
+- Polling on any page other than the game board
+- Per-user configurable polling intervals
+- Animations or loading skeletons beyond what already exists
+
+## Behavior
+
+| State | Auto poll | Manual button |
+|---|---|---|
+| Your turn | Off | Hidden |
+| Not your turn | Every 30s | Visible |
+- Game completed | Off | Hidden — game completion is detected via the `completed` boolean derived in `lib/hooks/use-game-state.ts`
+
+The "Refresh" button occupies the same location as the "Your turn" indicator — the two states are mutually exclusive, so the button replaces that indicator when it is not the player's turn. It must meet the 44px minimum touch target.
+
+While a refresh is in-flight, the button shows a loading state and is disabled to prevent double-fetches.
+
+## Success Criteria
+
+- Server polling requests drop substantially for games with 2+ players waiting
+- Players waiting on opponents can manually refresh at will
+- No regressions in action-driven refreshes (`onActionComplete` still fires immediately)
+- Existing unit tests for `use-polling.ts` continue to pass; new behavior is covered
+
+## Files Likely Affected
+
+- `lib/hooks/use-polling.ts` — expose or accept a configurable interval; support disabling the timer
+- `lib/hooks/use-game-state.ts` — pass turn-aware `enabled`/`interval` to the polling hook
+- `app/games/[gameId]/game-page.tsx` — wire refresh button visibility to `myTurn`
+- Relevant component in the game board where "Your turn" is currently displayed
+
+## Open Questions
+
+1. Should the 30-second fallback poll also be disabled when the browser tab is hidden (in addition to the existing visibility handler)? The current hook already pauses on hidden tabs, so this may be free.
+2. What copy should the button use — "Refresh", "Check for updates", or an icon-only button?

--- a/docs/plans/2026-04-21-001-feat-polling-manual-refresh-plan.md
+++ b/docs/plans/2026-04-21-001-feat-polling-manual-refresh-plan.md
@@ -1,0 +1,245 @@
+---
+title: "feat: Add Manual Refresh Button and Reduce Background Polling"
+type: feat
+status: active
+date: 2026-04-21
+origin: docs/brainstorms/polling-manual-refresh-requirements.md
+---
+
+# feat: Add Manual Refresh Button and Reduce Background Polling
+
+## Overview
+
+Replace continuous 3-second polling with a turn-aware polling strategy: disable the background timer when it is the current player's turn (game state is already fresh from the last action), slow it to 30 seconds when waiting on opponents, and expose a manual "Refresh" button in the status bar that replaces the "Your turn" indicator while waiting. Tab-focus and network-recovery triggers are retained unchanged.
+
+## Problem Frame
+
+The current `usePolling` hook fetches game state every 3 seconds for every connected client. Polling is only useful when a player is waiting for an opponent — while it's your own turn, state is already fresh from the `onActionComplete` refetch that fires after every action. With multiple concurrent games, this creates unnecessary server load. SSE is the long-term fix; this plan is the MVP bridge.
+
+(see origin: `docs/brainstorms/polling-manual-refresh-requirements.md`)
+
+## Requirements Trace
+
+- R1. Background poll timer is disabled for the entire duration of a player's own turn (level-based)
+- R2. Background poll interval drops to 30 seconds when it is not the player's turn
+- R3. A manual "Refresh" button appears in place of the "Your turn" indicator when waiting; it is hidden during the player's own turn and after game completion
+- R4. While a refresh is in-flight, the button is in a loading/disabled state to prevent double-fetches
+- R5. Tab-focus and online-event refresh triggers are retained unchanged
+- R6. `onActionComplete` refetch continues to fire immediately after every player action
+- R7. Existing `use-polling.ts` unit tests continue to pass; new behavior has test coverage
+
+## Scope Boundaries
+
+- Game board page only — no other pages use polling
+- No SSE, WebSocket, or push-notification implementation
+- No per-user configurable intervals
+- No new loading skeletons or animations beyond the button loading state
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `lib/hooks/use-polling.ts` — `interval` is already reactive; changing the prop causes the `useEffect([enabled, poll, interval])` to cancel the old loop and start a new one. Setting `enabled: false` clears the timer and stops polling; flipping back to `true` immediately triggers a fresh fetch and new loop.
+- `lib/hooks/use-game-state.ts` — already accepts `interval?: number` and forwards it to `usePolling`. Also derives `myTurn`, `completed`, `loading`, and exposes `refetch` directly from `usePolling`.
+- `app/games/[gameId]/game-page.tsx` — calls `useGameState`, passes `refetch` as `onActionComplete` to `GameBoard`, and passes `myTurn` to `GameBoard`. Turn-aware interval logic belongs here alongside the hook call.
+- `components/game/game-status-bar.tsx` — renders the pill that says "Your turn" or "Waiting for …" based on `myTurn`. This is the correct placement for the refresh button — the pill slot is already mutually exclusive between the two states and sits next to the existing `isStale` "Reconnecting…" indicator.
+- `lib/hooks/__tests__/use-polling.test.ts` — Vitest + `@testing-library/react` (`renderHook`, `waitFor`, `act`). Fake timers via `vi.useFakeTimers({ shouldAdvanceTime: true })`. Time advancement wrapped in `await act(async () => { await vi.advanceTimersByTimeAsync(N); })`.
+
+### Institutional Learnings
+
+- Any component calling `useState`, `useEffect`, or a custom hook wrapping those must have `'use client'`. `GameStatusBar` will need this directive if it doesn't already have it once it gains event-handler props. (see `docs/solutions/best-practices/use-client-directive-ssr-migration-2026-04-19.md`)
+- Gate hover/cursor CSS classes explicitly on a `disabled` variable — CSS `disabled` attribute alone does not suppress `:hover` on non-form elements. (see `docs/solutions/ui-bugs/game-ui-rendering-and-style-fixes-2026-04-19.md`)
+
+### External References
+
+None needed — local patterns are sufficient.
+
+## Key Technical Decisions
+
+- **Turn-aware polling via `enabled` and `interval` in `useGameState`:** The caller (`game-page.tsx`) passes `enabled: !myTurn && !completed` and `interval: 30000` to `useGameState`, which forwards both to `usePolling`. When `enabled` is `false`, `usePolling` clears its timer entirely — this is the mechanism for stopping polling on your turn and after game completion. The `interval: 30000` is always 30 s (not conditional) because it only applies when `enabled` is `true`. Rationale: keeps `usePolling` generic; the hook's `enabled` and `interval` props already support this contract without modification.
+- **Refresh button in `GameStatusBar`, not `GameBoard`:** Turn/connection status is already communicated there. Adding `onRefresh` and `isRefreshing` props keeps `GameBoard` unchanged.
+- **`isRefreshing` local state is required for re-fetch in-flight state:** `loading` from `usePolling` is only `true` until the first fetch completes and is never reset to `true` on subsequent polls or manual refetches. Therefore `loading` alone cannot disable the button during a re-fetch. In `game-page.tsx`, wrap `refetch` in a small async handler that sets/clears an `isRefreshing` boolean (`useState`) around the `await refetch()` call. Pass `isRefreshing` to `GameStatusBar` as the prop that disables the button. `loading` is not passed to `GameStatusBar` — `isRefreshing` covers both initial-load and re-fetch cases adequately for this button.
+- **Button copy deferred to implementation:** "Refresh" is the working assumption; a refresh icon (e.g., ↻) is a reasonable alternative. Resolve at implementation time with the 44 px touch-target constraint in mind.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should the 30s fallback also pause on hidden tabs?** The existing `visibilitychange` handler in `usePolling` already pauses polling while the tab is hidden and triggers one immediate fetch on return. This applies regardless of the configured interval — no additional work needed.
+- **`loading` for in-flight state on re-fetches:** Resolved — `isRefreshing` local state (not `loading`) is the button's disabled guard. See Key Technical Decisions.
+
+### Deferred to Implementation
+
+- Exact prop signature additions to `GameStatusBar` for `onRefresh` and `isRefreshing`
+- Button copy / icon choice (working assumption: "Refresh" text or ↻ icon, 44 px min touch target)
+- Exact Tailwind classes for the button's default, loading, and disabled states (follow existing pill styling in `game-status-bar.tsx`)
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+### Turn-aware polling decision matrix
+
+| `myTurn` | `completed` | `enabled` passed to `usePolling` | `interval` passed | Refresh button |
+|---|---|---|---|---|
+| `true` | `false` | `false` | — (irrelevant) | Hidden |
+| `false` | `false` | `true` | `30000` | Visible |
+| `*` | `true` | `false` | — (irrelevant) | Hidden |
+
+### Component data flow
+
+```
+game-page.tsx
+  useGameState({ gameId, enabled: !myTurn && !completed, interval: 30000 })
+    → { myTurn, completed, loading, refetch, ... }
+  
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const handleRefresh = async () => {
+    setIsRefreshing(true)
+    await refetch()
+    setIsRefreshing(false)
+  }
+
+  <GameStatusBar
+    myTurn={myTurn}
+    completed={!!completed}
+    isRefreshing={isRefreshing}
+    onRefresh={handleRefresh}
+    ...existing props...
+  />
+    → shows "Your turn" pill when myTurn
+    → shows "Refresh" button (calls onRefresh, disabled when isRefreshing) when !myTurn && !completed
+    → shows nothing in that slot when completed
+
+  <GameBoard
+    onActionComplete={refetch}   ← unchanged
+    ...
+  />
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Make polling turn-aware in `useGameState` and `game-page.tsx`**
+
+  **Goal:** Stop background polling while it's the player's turn and slow it to 30 seconds while waiting; wire `isRefreshing` state and `onRefresh` handler for the refresh button.
+
+  **Requirements:** R1, R2, R5, R6
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `lib/hooks/use-game-state.ts`
+  - Modify: `app/games/[gameId]/game-page.tsx`
+
+  **Approach:**
+  - `useGameState` needs to accept (or derive internally) an `enabled` param separate from the auth gate, so the caller can disable the timer for turn-based reasons. The simplest path: add an optional `enabled` option that defaults to `true` and is ANDed with `!!playerId` when passed to `usePolling`.
+  - In `game-page.tsx`, derive `enabled = !myTurn && !completed` and `interval = 30000`, then pass them to `useGameState`. Because `myTurn` is derived from the game data that `useGameState` returns, and `useGameState` uses `enabled` to control polling, this creates a reactive loop: when `myTurn` flips to `false` (opponent took their turn), `enabled` becomes `true`, which restarts polling immediately. When `myTurn` flips to `true`, `enabled` becomes `false`, which stops polling.
+  - The initial render has `myTurn = false` (no game data yet) so `enabled` starts `true` — polling fires immediately on mount, which is correct.
+
+  **Patterns to follow:**
+  - Existing `enabled: !!playerId` auth gate in `lib/hooks/use-game-state.ts`
+  - Existing `interval` forwarding pattern in `lib/hooks/use-game-state.ts`
+
+  **Test scenarios:**
+  - Happy path: when `myTurn` is false and game is not completed, `usePolling` is called with `enabled: true` and `interval: 30000`
+  - Happy path: when `myTurn` is true, `usePolling` is called with `enabled: false`
+  - Happy path: when `completed` is truthy, `usePolling` is called with `enabled: false`
+  - Edge case: initial render before first fetch (`myTurn` defaults to false) — polling fires immediately on mount
+  - Integration: flipping `myTurn` from `true` to `false` (opponent acts) causes an immediate refetch and restarts the 30-second loop
+  - Edge case: `enabled: false` passed by caller + authenticated user → `usePolling` receives `enabled: false` (AND-gate: caller flag ANDed with `!!playerId`)
+  - Edge case: `enabled: true` passed by caller + unauthenticated user → `usePolling` receives `enabled: false` (auth gate still wins)
+
+  **Verification:**
+  - Unit tests for `useGameState` cover the three `enabled`/`interval` combinations in the decision matrix
+  - `onActionComplete` (refetch) still fires in `game-page.tsx` after actions — no regression
+
+---
+
+- [ ] **Unit 2: Add "Refresh" button to `GameStatusBar`**
+
+  **Goal:** Replace the "Your turn" / "Waiting for…" pill slot with a manual refresh button when it is not the player's turn (and the game is not over).
+
+  **Requirements:** R3, R4
+
+  **Dependencies:** Unit 1 (requires `onRefresh` prop to be plumbed from `game-page.tsx`)
+
+  **Files:**
+  - Modify: `components/game/game-status-bar.tsx`
+
+  **Approach:**
+  - Add `onRefresh: () => void` and `isRefreshing: boolean` props to `GameStatusBarProps`.
+  - In the pill slot: when `myTurn` is true, render "Your turn" as today; when `myTurn` is false and game is not completed, render a button that calls `onRefresh` and is disabled when `isRefreshing` is true.
+  - The button must meet the 44 px minimum touch target (match existing pill height or use `min-h-[44px] min-w-[44px]`).
+  - Explicitly gate hover and cursor CSS classes on a `disabled` variable (not CSS `disabled` alone) per the institutional learning.
+  - If `GameStatusBar` is currently a server component, add `'use client'` — it will need an event handler.
+
+  **Patterns to follow:**
+  - Existing pill styling in `components/game/game-status-bar.tsx` (lines 62–71)
+  - `disabled` hover-gating pattern from `docs/solutions/ui-bugs/game-ui-rendering-and-style-fixes-2026-04-19.md`
+  - 44 px touch-target convention from `AGENTS.md`
+
+  **Test scenarios:**
+  - Happy path: renders "Your turn" pill when `myTurn` is true
+  - Happy path: renders a Refresh button (not "Your turn") when `myTurn` is false and `completed` is false
+  - Happy path: renders neither (or a completed state) when game is completed
+  - Happy path: clicking Refresh button calls `onRefresh` once
+  - Error path: button is disabled and shows loading indicator when `isRefreshing` is true
+  - Edge case: clicking button while already refreshing (`isRefreshing: true`) does not call `onRefresh` a second time
+  - Edge case: button has at least 44 px height (verify via rendered class or snapshot)
+
+  **Verification:**
+  - Visual inspection in dev: button appears in the status bar when waiting, disappears when it's your turn
+  - Tests pass for all seven scenarios above
+
+---
+
+- [ ] **Unit 3: Update `use-polling.ts` tests to cover new `enabled`/`interval` behavior (if needed)**
+
+  **Goal:** Ensure the polling hook's test suite covers the reactive `interval` and `enabled` contracts that Units 1–2 rely on.
+
+  **Requirements:** R7
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `lib/hooks/__tests__/use-polling.test.ts`
+
+  **Approach:**
+  - Review existing test coverage. The current suite already covers `enabled: false` (no-poll test) and interval timing. Gaps to fill:
+    - Changing `interval` mid-lifecycle (via `renderHook` `rerender`) causes the old timer to cancel and a new loop to start at the new interval
+    - Changing `enabled` from `false` to `true` triggers an immediate fetch
+  - Add these as new `it` blocks following existing fake-timer patterns.
+
+  **Patterns to follow:**
+  - `lib/hooks/__tests__/use-polling.test.ts` — `renderHook` with `rerender`, `vi.advanceTimersByTimeAsync`, `await act(async () => {...})`
+
+  **Test scenarios:**
+  - Changing `interval` from 3000 to 30000 mid-lifecycle causes the next tick to fire at the new interval, not the old one
+  - Changing `enabled` from `false` to `true` triggers one immediate fetch and then the interval loop
+
+  **Verification:**
+  - `npm test` (or `npx vitest run`) passes with no regressions on existing tests and new tests green
+
+## System-Wide Impact
+
+- **Interaction graph:** `usePolling` ← `useGameState` ← `game-page.tsx` ← `GameStatusBar`. Only this chain is affected. `GameBoard`, `useSuggestions`, `ScoreBoard`, and all other components are unchanged.
+- **Error propagation:** `isStale` behavior is unchanged — the hook sets it on fetch failure and shows "Reconnecting…" regardless of interval. The manual refresh button and the `isStale` pill coexist in the status bar.
+- **Concurrent fetch race during turn transition:** When `myTurn` flips `false` (opponent acted), polling restarts immediately. If the user also clicks Refresh during that in-flight poll, two fetches race. The last response to resolve wins and calls `setData` — this is benign because both fetches return the same authoritative server state. No deduplication is needed; the `isRefreshing` flag prevents the user from triggering a *third* overlapping fetch via the button.
+- **API surface parity:** No API changes. `usePolling` and `useGameState` signatures gain optional props only — no breaking changes to callers.
+- **Integration coverage:** The key integration scenario — "opponent acts → `myTurn` becomes false → polling restarts → game state updates" — cannot be fully proven by unit tests alone. An end-to-end or manual test covering a two-player turn cycle covers this.
+- **Unchanged invariants:** `onActionComplete={refetch}` in `game-page.tsx` fires immediately after every player action regardless of polling state. This is not touched.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `myTurn` starts as `false` on initial render, causing one immediate fetch before game data loads | Intentional and correct — the poll on mount fetches the initial game state |
+| Reactive `enabled` loop between `myTurn` (derived from poll result) and poll `enabled` flag causes infinite re-renders | `myTurn` only changes when `game` data changes; `enabled` is a computed value, not `setState` — no render loop |
+| Button touch target too small on mobile | Enforce `min-h-[44px]` in implementation per AGENTS.md convention |
+| `loading` from `usePolling` only reflects the initial load, not re-fetch in-flight | `isRefreshing` local state in `game-page.tsx` wraps `refetch` with set/clear around the async call; passed as the button's disabled prop |
+
+## Sources & References
+
+- **Origin document:** [`docs/brainstorms/polling-manual-refresh-requirements.md`](docs/brainstorms/polling-manual-refresh-requirements.md)
+- Related code: `lib/hooks/use-polling.ts`, `lib/hooks/use-game-state.ts`, `components/game/game-status-bar.tsx`, `app/games/[gameId]/game-page.tsx`
+- Institutional learnings: `docs/solutions/best-practices/use-client-directive-ssr-migration-2026-04-19.md`, `docs/solutions/ui-bugs/game-ui-rendering-and-style-fixes-2026-04-19.md`

--- a/docs/solutions/best-practices/react-async-handler-memoization-and-prop-consistency-2026-04-21.md
+++ b/docs/solutions/best-practices/react-async-handler-memoization-and-prop-consistency-2026-04-21.md
@@ -1,0 +1,197 @@
+---
+title: "React async handlers: memoization, error safety, prop consistency, and test coverage"
+date: 2026-04-21
+category: best-practices
+module: game-page
+problem_type: best_practice
+component: frontend_stimulus
+severity: medium
+applies_when:
+  - "Adding a manual refresh button alongside a polling hook in a React component"
+  - "Wrapping async refetch calls in onClick event handlers"
+  - "Defining optional vs required props on layered parent/child component interfaces"
+  - "Testing error paths for async state-setting callbacks (e.g. isRefreshing resets)"
+  - "Asserting that configuration values (e.g. polling intervals) are forwarded to inner hooks"
+related_components:
+  - testing_framework
+tags:
+  - react
+  - usecallback
+  - async-error-handling
+  - optional-props
+  - typescript
+  - polling
+  - testing
+  - vitest
+---
+
+# React async handlers: memoization, error safety, prop consistency, and test coverage
+
+## Context
+
+When PR #2 (`feat/polling-manual-refresh`) added a Refresh button to the game page alongside a polling hook, a code review surfaced four compounding issues:
+
+1. `GameBoard` declared `onRefresh`/`isRefreshing` as **required** while child `GameStatusBar` declared them **optional** — forcing every caller of `GameBoard` to supply a refresh feature.
+2. `handleRefresh` was a plain `async function` inside the component body — new reference every render, unnecessary re-renders downstream.
+3. `handleRefresh` used `try/finally` but no `catch` — rejected promise escapes as an unhandled rejection at runtime and in tests.
+4. No test verified `isRefreshing` resets on the error path; no test asserted the interval value was forwarded correctly.
+
+## Guidance
+
+### 1. Match optional/required across layered component interfaces
+
+When a prop is optional on a child, make it optional on the parent too. Required props on a wrapper that the wrapped component treats as optional force callers to supply a feature they may not need.
+
+```typescript
+// Before — GameBoard forces callers to supply refresh props
+interface GameBoardProps {
+  onRefresh: () => Promise<void>;
+  isRefreshing: boolean;
+}
+
+// After — matches GameStatusBar's interface
+interface GameBoardProps {
+  onRefresh?: () => Promise<void>;
+  isRefreshing?: boolean;
+}
+```
+
+When passing these optional props down, use optional chaining at the call site: `onClick={() => onRefresh?.()}`.
+
+### 2. Memoize async handlers with `useCallback` — and always `catch`
+
+Inline `async function` declarations produce a new reference every render. Wrap with `useCallback` to stabilize the reference.
+
+Also: `try/finally` alone does **not** prevent an unhandled rejection. When a React `onClick` returns a rejected promise, that rejection escapes the async function and becomes unhandled. `catch {}` (even empty) consumes it before it leaves:
+
+```typescript
+// Before — new reference every render; rejection escapes try/finally
+async function handleRefresh() {
+  setIsRefreshing(true);
+  try {
+    await refetch();
+  } finally {
+    setIsRefreshing(false); // runs, but error still propagates
+  }
+}
+
+// After — stable reference; rejection consumed
+import { useCallback, useState } from "react";
+
+const handleRefresh = useCallback(async () => {
+  setIsRefreshing(true);
+  try {
+    await refetch();
+  } catch {
+    // Swallow — isRefreshing resets via finally; surface errors when UX is ready
+  } finally {
+    setIsRefreshing(false);
+  }
+}, [refetch]);
+```
+
+The `catch {}` is not optional boilerplate. Without it, the rejection propagates out of the async function to the caller (the synthetic event handler), causing an unhandled promise rejection in both browser and test environments.
+
+### 3. Test async error paths at the component level
+
+To verify `isRefreshing` resets on both success and failure, mount the real page component with mocked dependencies. Stub `GameBoard` as a minimal div that exposes `onRefresh` as a button — this drives the actual handler in the page without rendering the full game UI:
+
+```typescript
+// app/games/[gameId]/__tests__/game-page.test.tsx
+vi.mock("@/lib/hooks/use-game-state", () => ({ useGameState: vi.fn() }));
+vi.mock("next/navigation", () => ({ useParams: vi.fn().mockReturnValue({ gameId: "game-abc" }) }));
+vi.mock("@/components/auth/require-auth", () => ({
+  RequireAuth: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("@/components/game/game-board", () => ({
+  GameBoard: ({
+    onRefresh,
+    isRefreshing,
+  }: {
+    onRefresh?: () => Promise<void>;
+    isRefreshing?: boolean;
+  }) => (
+    <div>
+      <span data-testid="refreshing">{String(isRefreshing)}</span>
+      {/* Use a wrapper arrow — passes onClick's MouseEvent correctly */}
+      <button onClick={() => onRefresh?.()}>Refresh</button>
+    </div>
+  ),
+}));
+
+it("resets isRefreshing to false after refetch rejects", async () => {
+  mockUseGameState.mockReturnValue({
+    ...baseState,
+    refetch: vi.fn().mockRejectedValue(new Error("network error")),
+  });
+
+  render(<GamePage />);
+  fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+  await waitFor(() => {
+    expect(screen.getByTestId("refreshing").textContent).toBe("false");
+  });
+});
+```
+
+> **Note:** Pass `onRefresh` to `onClick` via `() => onRefresh?.()`, not as `onClick={onRefresh}` directly. `onClick` expects `MouseEventHandler<HTMLButtonElement>`, and passing an `async () => Promise<void>` directly creates a type mismatch (wrong parameter list). The arrow wrapper fixes both the type and the optional-call.
+
+### 4. Assert forwarded hook arguments with a spy-wrapping mock
+
+To verify that a configuration value (e.g. polling interval) is correctly forwarded from one hook to an inner hook, use Vitest's `importOriginal` factory — it wraps the real implementation in a spy without replacing it, keeping real behaviour while enabling argument assertions.
+
+> **Import ordering:** Place all `import` statements at the **top** of the file, before any `vi.mock` calls in source order. Vitest hoists `vi.mock` above imports at transform time, so the import will resolve to the mocked module regardless of where it appears. However, writing the import mid-file misleads readers into thinking order doesn't matter.
+
+```typescript
+// At top of file (imports hoisted by Vitest above vi.mock calls at build time)
+import { usePolling } from "../use-polling";
+import { useGameState } from "../use-game-state";
+
+vi.mock("../use-polling", async (importOriginal) => {
+  // importOriginal() returns the real module; vi.fn(actual.usePolling) wraps it in a spy
+  const actual = (await importOriginal()) as typeof import("../use-polling");
+  return { ...actual, usePolling: vi.fn(actual.usePolling) };
+});
+
+const mockUsePolling = vi.mocked(usePolling);
+
+it("forwards the configured interval to usePolling when waiting for opponent", async () => {
+  renderHook(() => useGameState({ gameId: GAME_ID, interval: 30000 }));
+
+  await waitFor(() => expect(mockGetGame).toHaveBeenCalledTimes(1));
+
+  expect(mockUsePolling).toHaveBeenCalledWith(
+    expect.objectContaining({ interval: 30000 }),
+  );
+});
+```
+
+> **Type safety note:** `importOriginal<typeof import(...)>()` looks like a checked inference but is actually an unchecked cast. Using `as typeof import('../use-polling')` (shown above) makes the cast explicit and visible — prefer this over the generic form.
+
+## Why This Matters
+
+| Gap | Runtime impact |
+|-----|----------------|
+| Required props on parent, optional on child | Callers forced to plumb unused props; refactoring is harder |
+| Unmemoized callback | Child subtrees re-render on every parent render |
+| `try/finally` without `catch` on async onClick | Unhandled rejection in browser; phantom errors in test suite |
+| No error-path test | `isRefreshing` can get stuck at `true`, permanently disabling the Refresh button after a network error |
+| Interval not asserted | Polling can silently degrade (e.g. 3s instead of 30s) with no failing test |
+
+## When to Apply
+
+- Any component that holds `isLoading`/`isRefreshing`-style state and calls an async function from an event handler
+- Any wrapper component that passes optional-in-child props through its own interface
+- Any hook that accepts a configuration value and forwards it to an inner hook — assert the forwarded value in tests
+- Any async `onClick` handler — always add `catch {}` if not surfacing errors to UI
+
+## Related
+
+- `components/game/game-status-bar.tsx` — the child component whose optional interface `GameBoard` now matches
+- `lib/hooks/use-game-state.ts` — hooks that forward interval to `usePolling`
+- `lib/hooks/__tests__/use-game-state.test.ts` — spy-wrapping mock example for `usePolling`
+- `app/games/[gameId]/__tests__/game-page.test.tsx` — error-path test for `handleRefresh`
+
+## Notes
+
+**ESLint constraint — deriving state that feeds the hook providing the data:** This codebase has custom rules banning `setState` inside `useEffect` and `ref.current` reads/writes during render. When `pollingEnabled` must be derived from game state, but game state comes from `usePolling` (which needs `pollingEnabled` as input), the only lint-compliant approach is React's "adjust state during render" pattern — compare a tracked key to the current one in the render body and call `setState` synchronously when they diverge. React re-runs the component before painting. Do **not** use `useEffect` or `useRef` for this case in this codebase.

--- a/lib/hooks/__tests__/use-game-state.test.ts
+++ b/lib/hooks/__tests__/use-game-state.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useGameState } from "../use-game-state";
+
+// Mock dependencies
+vi.mock("../use-auth", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api/games", () => ({
+  getGame: vi.fn(),
+}));
+
+import { useAuth } from "../use-auth";
+import { getGame } from "@/lib/api/games";
+
+const mockUseAuth = vi.mocked(useAuth);
+const mockGetGame = vi.mocked(getGame);
+
+const PLAYER_ID = "player-uid-123";
+const GAME_ID = "game-abc-456";
+
+const mockStartedGame = {
+  status: "BIDDING" as const,
+  id: GAME_ID,
+  active_player_id: "other-player",
+  players: [],
+  scores: {},
+  bid_amount: null,
+  bidder_player_id: null,
+  dealer_player_id: null,
+  trump: null,
+};
+
+const mockMyTurnGame = {
+  ...mockStartedGame,
+  active_player_id: PLAYER_ID,
+};
+
+const mockCompletedGame = {
+  status: "WON" as const,
+  id: GAME_ID,
+  winner: { id: "other-player" },
+  scores: {},
+  players: [],
+};
+
+describe("useGameState", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockUseAuth.mockReturnValue({
+      user: { uid: PLAYER_ID } as ReturnType<typeof useAuth>["user"],
+      loading: false,
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+      getToken: vi.fn(),
+    });
+    mockGetGame.mockResolvedValue(mockStartedGame as never);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("starts polling immediately on mount (waiting for opponent)", async () => {
+    renderHook(() => useGameState({ gameId: GAME_ID, interval: 30000 }));
+
+    await waitFor(() => {
+      expect(mockGetGame).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("derives myTurn false when active player is not self", async () => {
+    const { result } = renderHook(() =>
+      useGameState({ gameId: GAME_ID, interval: 30000 }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.myTurn).toBe(false);
+    });
+  });
+
+  it("derives myTurn true when active player is self", async () => {
+    mockGetGame.mockResolvedValue(mockMyTurnGame as never);
+
+    const { result } = renderHook(() =>
+      useGameState({ gameId: GAME_ID, interval: 30000 }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.myTurn).toBe(true);
+    });
+  });
+
+  it("disables polling after myTurn becomes true", async () => {
+    mockGetGame.mockResolvedValue(mockMyTurnGame as never);
+
+    renderHook(() => useGameState({ gameId: GAME_ID, interval: 30000 }));
+
+    // Wait for initial fetch to complete
+    await waitFor(() => {
+      expect(mockGetGame).toHaveBeenCalledTimes(1);
+    });
+
+    const callsBefore = mockGetGame.mock.calls.length;
+
+    // Advance well past the 30s interval — should not poll again
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60000);
+    });
+
+    expect(mockGetGame.mock.calls.length).toBe(callsBefore);
+  });
+
+  it("disables polling when game is completed", async () => {
+    mockGetGame.mockResolvedValue(mockCompletedGame as never);
+
+    renderHook(() => useGameState({ gameId: GAME_ID, interval: 30000 }));
+
+    await waitFor(() => {
+      expect(mockGetGame).toHaveBeenCalledTimes(1);
+    });
+
+    const callsBefore = mockGetGame.mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60000);
+    });
+
+    expect(mockGetGame.mock.calls.length).toBe(callsBefore);
+  });
+
+  it("does not poll when unauthenticated (auth gate wins)", async () => {
+    mockUseAuth.mockReturnValue({
+      user: null,
+      loading: false,
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+      getToken: vi.fn(),
+    });
+
+    renderHook(() => useGameState({ gameId: GAME_ID, interval: 30000 }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60000);
+    });
+
+    expect(mockGetGame).not.toHaveBeenCalled();
+  });
+
+  it("polls at the configured interval when waiting for opponent", async () => {
+    renderHook(() => useGameState({ gameId: GAME_ID, interval: 30000 }));
+
+    await waitFor(() => {
+      expect(mockGetGame).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30000);
+    });
+
+    await waitFor(() => {
+      expect(mockGetGame).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/lib/hooks/__tests__/use-game-state.test.ts
+++ b/lib/hooks/__tests__/use-game-state.test.ts
@@ -11,8 +11,19 @@ vi.mock("@/lib/api/games", () => ({
   getGame: vi.fn(),
 }));
 
+vi.mock("../use-polling", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../use-polling")>();
+  return {
+    ...actual,
+    usePolling: vi.fn(actual.usePolling),
+  };
+});
+
 import { useAuth } from "../use-auth";
 import { getGame } from "@/lib/api/games";
+import { usePolling } from "../use-polling";
+
+const mockUsePolling = vi.mocked(usePolling);
 
 const mockUseAuth = vi.mocked(useAuth);
 const mockGetGame = vi.mocked(getGame);
@@ -163,5 +174,17 @@ describe("useGameState", () => {
     await waitFor(() => {
       expect(mockGetGame).toHaveBeenCalledTimes(2);
     });
+  });
+
+  it("forwards the configured interval to usePolling when waiting for opponent", async () => {
+    renderHook(() => useGameState({ gameId: GAME_ID, interval: 30000 }));
+
+    await waitFor(() => {
+      expect(mockGetGame).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockUsePolling).toHaveBeenCalledWith(
+      expect.objectContaining({ interval: 30000 }),
+    );
   });
 });

--- a/lib/hooks/__tests__/use-polling.test.ts
+++ b/lib/hooks/__tests__/use-polling.test.ts
@@ -168,4 +168,70 @@ describe("usePolling", () => {
     expect(result.current.data).toEqual({ id: 2 });
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
+
+  it("changing interval mid-lifecycle restarts the loop at the new interval", async () => {
+    const fetcher = vi.fn().mockResolvedValue({ id: 1 });
+
+    const { rerender } = renderHook(
+      ({ interval }: { interval: number }) => usePolling({ fetcher, interval }),
+      { initialProps: { interval: 3000 } },
+    );
+
+    // Wait for initial fetch
+    await waitFor(() => {
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    // Switch to 30s interval — effect re-runs, triggers an immediate fetch
+    rerender({ interval: 30000 });
+
+    await waitFor(() => {
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    // Advance 3s — old interval would have fired again, new one should not
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    // Advance to 30s from last fetch — new interval should fire now
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(27000);
+    });
+    await waitFor(() => {
+      expect(fetcher).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  it("changing enabled from false to true triggers an immediate fetch then the loop", async () => {
+    const fetcher = vi.fn().mockResolvedValue({ id: 1 });
+
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        usePolling({ fetcher, interval: 3000, enabled }),
+      { initialProps: { enabled: false } },
+    );
+
+    // Should not have fetched while disabled
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(fetcher).not.toHaveBeenCalled();
+
+    // Enable — should fire immediately
+    rerender({ enabled: true });
+
+    await waitFor(() => {
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    // Then fire again at the next interval
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    await waitFor(() => {
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/lib/hooks/use-game-state.ts
+++ b/lib/hooks/use-game-state.ts
@@ -62,7 +62,7 @@ export function useGameState({ gameId, interval = 3000 }: UseGameStateOptions) {
   const currentKey = `${game?.status ?? "none"}:${started?.active_player_id ?? ""}`;
   if (currentKey !== lastGameStatus) {
     setLastGameStatus(currentKey);
-    setPollingEnabled(!myTurn && !completed);
+    setPollingEnabled(!myTurn && completed === null);
   }
 
   const selfPlayer = started?.players.find(

--- a/lib/hooks/use-game-state.ts
+++ b/lib/hooks/use-game-state.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { usePolling } from "./use-polling";
 import { useAuth } from "./use-auth";
 import { getGame } from "@/lib/api/games";
@@ -13,7 +13,7 @@ import type {
 
 interface UseGameStateOptions {
   gameId: string;
-  /** Polling interval in ms. Default 3000. */
+  /** Polling interval in ms when waiting for opponents. Default 3000. */
   interval?: number;
 }
 
@@ -31,6 +31,13 @@ export function useGameState({ gameId, interval = 3000 }: UseGameStateOptions) {
   const { user } = useAuth();
   const playerId = user?.uid ?? "";
 
+  // pollingEnabled is derived from game state. It starts true so the initial
+  // fetch fires. We use the React-recommended "adjust state during render"
+  // pattern: track the last game status we processed and update pollingEnabled
+  // synchronously when it changes, avoiding setState-in-effect.
+  const [pollingEnabled, setPollingEnabled] = useState(true);
+  const [lastGameStatus, setLastGameStatus] = useState<string | null>(null);
+
   const fetcher = useCallback(() => {
     return getGame(playerId, gameId);
   }, [playerId, gameId]);
@@ -44,13 +51,19 @@ export function useGameState({ gameId, interval = 3000 }: UseGameStateOptions) {
   } = usePolling({
     fetcher,
     interval,
-    enabled: !!playerId,
+    enabled: !!playerId && pollingEnabled,
   });
 
   const started = game && isStartedGame(game) ? game : null;
   const completed = game?.status === "WON" ? (game as CompletedGame) : null;
-
   const myTurn = started?.active_player_id === playerId;
+
+  // Derive a key that captures whether polling should be active.
+  const currentKey = `${game?.status ?? "none"}:${started?.active_player_id ?? ""}`;
+  if (currentKey !== lastGameStatus) {
+    setLastGameStatus(currentKey);
+    setPollingEnabled(!myTurn && !completed);
+  }
 
   const selfPlayer = started?.players.find(
     (p): p is SelfInRound => p.id === playerId && isSelf(p),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,8 @@ import path from "path";
 export default defineConfig({
   test: {
     environment: "jsdom",
+    globals: true,
+    setupFiles: ["./vitest.setup.ts"],
   },
   resolve: {
     alias: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,7 @@
+import "@testing-library/jest-dom";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
## Summary

The game page was polling the server every 3 seconds unconditionally — including when it was already the player's own turn and no server-side change was possible. This PR brings that under control ahead of SSE support.

## What changed

**Adaptive polling in `useGameState`:** Polling is now disabled entirely when it's the player's own turn (game state can't change until they act) and slowed to a 30-second interval when waiting for opponents. The `pollingEnabled` flag is derived from game state using the React "adjust state during render" pattern — tracking a `lastGameStatus` key to synchronously update polling on state changes without an effect.

**Manual Refresh button in `GameStatusBar`:** The static "Waiting for \<player\>..." pill is replaced by a tappable Refresh button that fires an immediate fetch. The button is disabled during in-flight requests and re-enabled via `try/finally` in `handleRefresh` — ensuring it can't get stuck disabled if `refetch()` throws. Props `onRefresh` and `isRefreshing` are optional with safe defaults so callers in WON state don't need to pass them.

**Tests:** New test files cover `usePolling` interval behavior, `useGameState` polling enable/disable transitions, and `GameStatusBar` Refresh button rendering and interaction.

## Polling behavior after this change

| Situation | Poll interval |
|---|---|
| Player's own turn | Disabled (no background polling) |
| Waiting for opponent | 30 seconds |
| Game over (WON) | Disabled |
| Tab regains focus / network recovers | Immediate re-fetch (existing behavior) |

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Claude_Code-claude--sonnet--4.6-D97757?logo=claude&logoColor=white)