### PR TITLE
fix: allow dealer to take the bid at current value

### DIFF
--- a/components/game/bid-controls.tsx
+++ b/components/game/bid-controls.tsx
@@ -4,13 +4,28 @@ import type { BidValue } from "@/lib/api/types";
 
 interface BidControlsProps {
   currentBid: number | null;
+  canMatchCurrentBid?: boolean;
   disabled?: boolean;
   onBid: (amount: BidValue) => void;
 }
 
 const BID_VALUES: BidValue[] = [15, 20, 25, 30, 60];
 
-export function BidControls({ currentBid, disabled, onBid }: BidControlsProps) {
+function isBidValueDisabled(
+  value: BidValue,
+  currentBid: number | null,
+  canMatchCurrentBid: boolean,
+): boolean {
+  if (currentBid === null) return false;
+  return canMatchCurrentBid ? value < currentBid : value <= currentBid;
+}
+
+export function BidControls({
+  currentBid,
+  canMatchCurrentBid = false,
+  disabled,
+  onBid,
+}: BidControlsProps) {
   return (
     <div className="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
       <h3 className="mb-2 text-sm font-medium text-gray-500 dark:text-gray-400">
@@ -22,7 +37,7 @@ export function BidControls({ currentBid, disabled, onBid }: BidControlsProps) {
             key={value}
             type="button"
             onClick={() => onBid(value)}
-            disabled={disabled || (currentBid !== null && value <= currentBid)}
+            disabled={disabled || isBidValueDisabled(value, currentBid, canMatchCurrentBid)}
             className="min-h-[44px] min-w-[44px] rounded-lg bg-blue-600 px-4 py-2 font-bold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-500 dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
           >
             {value}

--- a/components/game/game-board.tsx
+++ b/components/game/game-board.tsx
@@ -126,6 +126,10 @@ export function GameBoard({
       {phase === "BIDDING" && myTurn && (
         <BidControls
           currentBid={started.bid_amount}
+          canMatchCurrentBid={
+            started.dealer_player_id != null &&
+            started.dealer_player_id === playerId
+          }
           disabled={actionInFlight}
           onBid={(amount: BidValue) => doAction({ type: "BID", amount })}
         />

--- a/docs/solutions/ui-bugs/dealer-bid-at-current-value-disabled-2026-04-21.md
+++ b/docs/solutions/ui-bugs/dealer-bid-at-current-value-disabled-2026-04-21.md
@@ -1,0 +1,96 @@
+---
+title: Dealer Cannot Bid at Current Bid Value
+date: 2026-04-21
+category: ui-bugs
+module: bidding
+problem_type: ui_bug
+component: frontend_stimulus
+severity: medium
+symptoms:
+  - Dealer's bid button is disabled at the current standing bid amount
+  - Dealer cannot take the bid at face value; must overbid or pass
+root_cause: logic_error
+resolution_type: code_fix
+tags:
+  - bidding
+  - dealer
+  - bid-controls
+  - disabled-state
+  - game-rules
+---
+
+# Dealer Cannot Bid at Current Bid Value
+
+## Problem
+
+In `components/game/bid-controls.tsx`, the bid button disabled condition used `value <= currentBid` for all players. The card game 110 allows the dealer to "take the bid" at the current standing value — matching, not exceeding, the current bid. Because the frontend applied the same strict inequality to everyone, the dealer's bid button was incorrectly disabled at the current bid value.
+
+## Symptoms
+
+- Dealer's bid button is disabled at the current standing bid amount
+- Dealer cannot exercise the take-the-bid privilege; forced to overbid or pass
+- Non-dealer players are unaffected
+
+## What Didn't Work
+
+No dead ends. The fix was straightforward once the game rule was identified.
+
+## Solution
+
+**Add `isDealer` prop to `BidControlsProps` and update the component signature:**
+
+```tsx
+// Before
+interface BidControlsProps {
+  currentBid: number | null;
+  disabled?: boolean;
+  onBid: (amount: BidValue) => void;
+}
+export function BidControls({ currentBid, disabled, onBid }: BidControlsProps)
+
+// After
+interface BidControlsProps {
+  currentBid: number | null;
+  isDealer?: boolean;
+  disabled?: boolean;
+  onBid: (amount: BidValue) => void;
+}
+export function BidControls({ currentBid, isDealer, disabled, onBid }: BidControlsProps)
+```
+
+**Update the disabled condition in `bid-controls.tsx`:**
+
+```tsx
+// Before
+disabled={disabled || (currentBid !== null && value <= currentBid)}
+
+// After
+disabled={disabled || (currentBid !== null && (isDealer ? value < currentBid : value <= currentBid))}
+```
+
+**Pass dealer identity from `game-board.tsx`:**
+
+```tsx
+<BidControls
+  currentBid={started.bid_amount}
+  isDealer={started.dealer_player_id === playerId}
+  disabled={actionInFlight}
+  onBid={(amount: BidValue) => doAction({ type: "BID", amount })}
+/>
+```
+
+## Why This Works
+
+The dealer-takes-bid rule requires a different threshold than the strict "must overbid" rule for other players. Threading `isDealer` down to the button-level disabled logic lets the comparison switch: dealers use `value < currentBid` (can match current), others use `value <= currentBid` (must exceed). The backend already enforces real authorization — this fix removes a UI-only block on a valid dealer action.
+
+## Prevention
+
+- When implementing bid or action controls, cross-reference game rules for role-specific exceptions (dealer privileges, trump caller rights, etc.) before coding disabled conditions
+- Encode player role as an explicit prop rather than deriving it inline in JSX; compute `const isDealer = started.dealer_player_id != null && started.dealer_player_id === playerId` before the return to make null-safety intent visible
+- Consider naming props for the _rule_ rather than the _role_ (e.g., `canMatchCurrentBid`) to make the intent of disabled logic self-documenting at the call site
+- Extract bid-floor logic into a named helper (`isBidValueDisabled(value, currentBid, canMatchCurrentBid)`) to make the three concerns (flight guard, null check, bid-floor) separately testable
+- Add a test for the dealer-at-current-bid case; the conditional `isDealer ? value < currentBid : value <= currentBid` is easy to accidentally flatten in a refactor
+
+## Related Issues
+
+- Related ui-bug: `docs/solutions/ui-bugs/game-ui-rendering-and-style-fixes-2026-04-19.md` — sibling issue involving incorrect disabled state on the Pass bid button


### PR DESCRIPTION
## Summary

In the card game 110, the dealer can "take the bid" at the current standing value rather than being forced to overbid. The bid button disabled logic used `value <= currentBid` for all players, which blocked this rule — the dealer's button for the current bid amount was always disabled.

## Fix

Added a `canMatchCurrentBid` prop to `BidControls` and extracted an `isBidValueDisabled` helper to make the threshold logic explicit and testable:

```
// Non-dealer: must strictly exceed current bid
value <= currentBid  →  disabled

// Dealer: can match current bid (take the bid)
value < currentBid   →  disabled
```

`canMatchCurrentBid` is derived in `game-board.tsx` with a null-safe check against `dealer_player_id`. The prop name encodes the rule ("can match") rather than the role ("is dealer"), keeping the component's disabled logic self-documenting at the call site.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Claude_Code-claude--sonnet--4.6-D97757?logo=claude&logoColor=white)